### PR TITLE
feat: use CMD/ENTRYPOINT from source image by default

### DIFF
--- a/builder/podman/builder.go
+++ b/builder/podman/builder.go
@@ -42,7 +42,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 	// Fetch default CMD and ENTRYPOINT
 	defaultCmd, _ := driver.Cmd(b.config.Image)
 	defaultEntrypoint, _ := driver.Entrypoint(b.config.Image)
-	
+
 	// Set defaults if not provided by the user
 	hasCmd, hasEntrypoint := false, false
 	for _, change := range b.config.Changes {
@@ -52,7 +52,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 			hasEntrypoint = true
 		}
 	}
-	
+
 	if !hasCmd && defaultCmd != "" {
 		b.config.Changes = append(b.config.Changes, "CMD "+defaultCmd)
 	}
@@ -74,8 +74,8 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 		&StepPull{},
 		&StepRun{},
 		&communicator.StepConnect{
-			Config: &b.config.Comm,
-			Host: commHost(b.config.Comm.Host()),
+			Config:    &b.config.Comm,
+			Host:      commHost(b.config.Comm.Host()),
 			SSHConfig: b.config.Comm.SSHConfigFunc(),
 			CustomConnect: map[string]multistep.Step{
 				"docker": &StepConnectPodman{},

--- a/builder/podman/driver.go
+++ b/builder/podman/driver.go
@@ -75,7 +75,7 @@ type ContainerConfig struct {
 	Volumes    map[string]string
 	TmpFs      []string
 	Privileged bool
-	Systemd string
+	Systemd    string
 }
 
 // This is the template that is used for the RunCommand in the ContainerConfig.

--- a/builder/podman/driver_podman.go
+++ b/builder/podman/driver_podman.go
@@ -183,7 +183,7 @@ func (d *PodmanDriver) Cmd(id string) (string, error) {
 		"podman",
 		"inspect",
 		"--format",
-		"{{json .Config.Cmd }}",
+		"{{if .Config.Cmd}} {{json .Config.Cmd}} {{else}} [] {{end}}",
 		id)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -200,7 +200,7 @@ func (d *PodmanDriver) Entrypoint(id string) (string, error) {
 		"podman",
 		"inspect",
 		"--format",
-		"{{json .Config.Entrypoint }}",
+		"{{if .Config.Entrypoint}} {{json .Config.Entrypoint}} {{else}} [] {{end}}",
 		id)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/builder/podman/driver_podman.go
+++ b/builder/podman/driver_podman.go
@@ -177,6 +177,40 @@ func (d *PodmanDriver) Sha256(id string) (string, error) {
 	return strings.TrimSpace(stdout.String()), nil
 }
 
+func (d *PodmanDriver) Cmd(id string) (string, error) {
+	var stderr, stdout bytes.Buffer
+	cmd := exec.Command(
+		"podman",
+		"inspect",
+		"--format",
+		"{{json .Config.Cmd }}",
+		id)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("Error: %s\n\nStderr: %s", err, stderr.String())
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func (d *PodmanDriver) Entrypoint(id string) (string, error) {
+	var stderr, stdout bytes.Buffer
+	cmd := exec.Command(
+		"podman",
+		"inspect",
+		"--format",
+		"{{json .Config.Entrypoint }}",
+		id)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("Error: %s\n\nStderr: %s", err, stderr.String())
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
 func (d *PodmanDriver) Login(repo, user, pass string) error {
 	d.l.Lock()
 

--- a/builder/podman/step_set_defaults.go
+++ b/builder/podman/step_set_defaults.go
@@ -1,0 +1,39 @@
+package podman
+
+import (
+	"context"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	"strings"
+)
+
+type StepSetDefaults struct{}
+
+func (s *StepSetDefaults) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	driver := state.Get("driver").(*PodmanDriver)
+	config := state.Get("config").(*Config)
+
+	// Fetch default CMD and ENTRYPOINT
+	defaultCmd, _ := driver.Cmd(config.Image)
+	defaultEntrypoint, _ := driver.Entrypoint(config.Image)
+
+	// Set defaults if not provided by the user
+	hasCmd, hasEntrypoint := false, false
+	for _, change := range config.Changes {
+		if strings.HasPrefix(change, "CMD") {
+			hasCmd = true
+		} else if strings.HasPrefix(change, "ENTRYPOINT") {
+			hasEntrypoint = true
+		}
+	}
+
+	if !hasCmd && defaultCmd != "" {
+		config.Changes = append(config.Changes, "CMD "+defaultCmd)
+	}
+	if !hasEntrypoint && defaultEntrypoint != "" {
+		config.Changes = append(config.Changes, "ENTRYPOINT "+defaultEntrypoint)
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepSetDefaults) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
With this change the images built will by default get the CMD and ENTRYPOINT from the source image if not overwritten by a user in the changes configuration option.
This replicates the behavior when building images from a Containerfile.

(Also submitted to the docker plugin: https://github.com/hashicorp/packer-plugin-docker/pull/167)