### PR TITLE
fix: enable release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,19 @@
+---
+name: draft-release
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  update_release_draft:
+    if: |
+      github.event.pull_request.merged &&
+      !contains(github.event.pull_request.labels.*.name, 'skip_changelog')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
release-drafter config already exists since https://github.com/Polpetta/packer-plugin-podman/commit/810bddb30396af04d29ebab928253c370ff1195e but the release-drafter wasn't actually enabled.